### PR TITLE
fix: HyperOS 2 with Android 15 can not change Effect in MiSound App

### DIFF
--- a/app/src/main/java/com/hchen/autoseffswitch/misound/AutoSEffSwitch.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/misound/AutoSEffSwitch.java
@@ -208,7 +208,11 @@ public class AutoSEffSwitch extends BaseHC {
 
     private static Object getMiSound() {
         if (MiSound == null) return null;
-        return newInstance(MiSound, 1, 0);
+        if (Build.VERSION.SDK_INT >= 35) {
+            return newInstance(MiSound, 0, 0);
+        } else {
+            return newInstance(MiSound, 1, 0);
+        }
     }
 
     private static boolean hasControl(Object o) {


### PR DESCRIPTION
修复了在安卓 15 的 HyperOS 2 上无法切换音效的问题
报错信息：
```log
11-25 02:18:46.130  6164  6164 D android.media.audiofx.presenter.BaseEffectPresenter: [TF-EFFECT] setMisoundEnableSafely error
11-25 02:18:46.130  6164  6164 W System.err: java.lang.UnsupportedOperationException: AudioEffect: invalid parameter operation
11-25 02:18:46.130  6164  6164 W System.err:    at android.media.audiofx.AudioEffect.checkStatus(AudioEffect.java:1450)
11-25 02:18:46.130  6164  6164 W System.err:    at android.media.audiofx.MiSound.setEnabled(MiSound.java:109)
11-25 02:18:46.130  6164  6164 W System.err:    at android.media.audiofx.presenter.BaseEffectPresenter.setMiSoundEnableSafely(BaseEffectPresenter.java:138)
11-25 02:18:46.130  6164  6164 W System.err:    at android.media.audiofx.presenter.QcomEffectPresenter.setDolbyActive(QcomEffectPresenter.java:34)
11-25 02:18:46.130  6164  6164 W System.err:    at android.media.audiofx.AudioEffectCenter.setEffectActive(AudioEffectCenter.java:134)
11-25 02:18:46.130  6164  6164 W System.err:    at java.lang.reflect.Method.invoke(Native Method)
11-25 02:18:46.130  6164  6164 W System.err:    at p0.a.f(Unknown Source:19)
11-25 02:18:46.130  6164  6164 W System.err:    at y.i.q0(Unknown Source:35)
11-25 02:18:46.130  6164  6164 W System.err:    at y.i.f0(Unknown Source:30)
11-25 02:18:46.130  6164  6164 W System.err:    at y.i.a0(Unknown Source:0)
11-25 02:18:46.130  6164  6164 W System.err:    at y.g.onPreferenceChange(Unknown Source:2)
11-25 02:18:46.130  6164  6164 W System.err:    at androidx.preference.Preference.callChangeListener(Unknown Source:4)
11-25 02:18:46.130  6164  6164 W System.err:    at miuix.preference.DropDownPreference$a$a.run(Unknown Source:22)
11-25 02:18:46.130  6164  6164 W System.err:    at android.os.Handler.handleCallback(Handler.java:959)
11-25 02:18:46.130  6164  6164 W System.err:    at android.os.Handler.dispatchMessage(Handler.java:100)
11-25 02:18:46.130  6164  6164 W System.err:    at android.os.Looper.loopOnce(Looper.java:249)
11-25 02:18:46.130  6164  6164 W System.err:    at android.os.Looper.loop(Looper.java:337)
11-25 02:18:46.130  6164  6164 W System.err:    at android.app.ActivityThread.main(ActivityThread.java:9572)
11-25 02:18:46.130  6164  6164 W System.err:    at java.lang.reflect.Method.invoke(Native Method)
11-25 02:18:46.130  6164  6164 W System.err:    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
11-25 02:18:46.130  6164  6164 W System.err:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:935)
```