### PR TITLE
fix: some HyperOS 2 device use AudioEffectCenter without prop

### DIFF
--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
@@ -77,7 +77,8 @@ public class NewAutoSEffSwitch extends BaseHC {
     }
 
     public static boolean isSupportFW() {
-        return SystemPropTool.getProp("ro.vendor.audio.fweffect", false);
+        // 部分机型 OS2 没有对应 Prop 但是使用 AudioEffectCenter
+        return SystemPropTool.getProp("ro.vendor.audio.fweffect", false) || existsClass("android.media.audiofx.AudioEffectCenter");
     }
 
     @Override


### PR DESCRIPTION
部分机型 OS2 没有对应 Prop 但是使用 AudioEffectCenter，并且有沉浸声选项
例子：小米14