### PR TITLE
fix: 修复连接小尾巴时的检测 & 完善音质音效冷启动时的判断逻辑

### DIFF
--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
@@ -52,7 +52,6 @@ public class NewAutoSEffSwitch extends BaseHC {
     private Context mContext;
     public static DexKitBridge mDexKit;
     public static boolean isEarPhoneConnection = false;
-    public static boolean isWiredHeadsetConnection = false;
     public static boolean isBroadcastReceiverCanUse = false;
     public static boolean shouldFixXiaoMiShit = false;
     public static AudioManager mAudioManager;
@@ -105,7 +104,6 @@ public class NewAutoSEffSwitch extends BaseHC {
             mFWAudioEffectControl.setBackups(backupsUtils);
         }
 
-        isWiredHeadsetConnection = checkIsWiredHeadset();
         updateEarPhoneState();
     }
 
@@ -124,7 +122,10 @@ public class NewAutoSEffSwitch extends BaseHC {
 
         AudioDeviceInfo[] outputs = mAudioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
         for (AudioDeviceInfo info : outputs) {
-            if (info.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP || info.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET) {
+            if (info.getType() == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+                    info.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+                    info.getType() == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
+                    info.getType() == AudioDeviceInfo.TYPE_USB_HEADSET) {
                 logI(TAG, "getEarPhoneState: isEarPhoneConnection: true.");
                 return true;
             }
@@ -138,9 +139,19 @@ public class NewAutoSEffSwitch extends BaseHC {
         // 检查有线耳机
         AudioDeviceInfo[] outputs = mAudioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
         for (AudioDeviceInfo info : outputs) {
-            if (info.getType() == AudioDeviceInfo.TYPE_WIRED_HEADSET) {
-                logI(TAG, "checkIsWiredHeadset: wired headset: true.");
-                return true;
+            switch (info.getType()) {
+                case AudioDeviceInfo.TYPE_WIRED_HEADSET -> {
+                    logI(TAG, "checkIsWiredHeadset: wired headset: true.");
+                    return true;
+                }
+                case AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> {
+                    logI(TAG, "checkIsWiredHeadset: wired headphones: true.");
+                    return true;
+                }
+                case AudioDeviceInfo.TYPE_USB_HEADSET -> {
+                    logI(TAG, "checkIsWiredHeadset: usb headset: true.");
+                    return true;
+                }
             }
         }
         logI(TAG, "checkIsWiredHeadset: wired headset: false.");
@@ -186,13 +197,9 @@ public class NewAutoSEffSwitch extends BaseHC {
                                 dump();
                             } else if (state == 0) {
                                 if (shouldFixXiaoMiShit) {
-                                    isEarPhoneConnection = true;
                                     shouldFixXiaoMiShit = false;
                                     return;
                                 }
-                                if (!isEarPhoneConnection) return; // 没连接过关什么？
-                                if (!isWiredHeadsetConnection) return; // 没连接有线耳机关什么？
-                                isWiredHeadsetConnection = false;
 
                                 logI(TAG, "ACTION_HEADSET_PLUG DISCONNECTED!");
                                 isEarPhoneConnection = false;

--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/AudioEffectControl.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/AudioEffectControl.java
@@ -142,12 +142,13 @@ public class AudioEffectControl implements IControl {
                             if (isBroadcastReceiverCanUse) return;
                             Object bluetoothDevice = getArgs(1);
                             if (bluetoothDevice != null) {
-                                // isEarPhoneConnection = true; // 这里不赋值 true 为了防止音质音效通过 ACTION_HEADSET_PLUG DISCONNECTED! 切换回音效。
+                                isEarPhoneConnection = true;
                                 shouldFixXiaoMiShit = true;
                                 updateLastEffectState();
                                 setEffectToNone(mContext);
                             } else {
                                 isEarPhoneConnection = false;
+                                shouldFixXiaoMiShit = true;
                                 resetAudioEffect();
                             }
                         }

--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/FWAudioEffectControl.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/FWAudioEffectControl.java
@@ -140,12 +140,13 @@ public class FWAudioEffectControl implements IControl {
                             if (isBroadcastReceiverCanUse) return;
                             Object bluetoothDevice = getArgs(1);
                             if (bluetoothDevice != null) {
-                                // isEarPhoneConnection = true; // 这里不赋值 true 为了防止音质音效通过 ACTION_HEADSET_PLUG DISCONNECTED! 切换回音效。
+                                isEarPhoneConnection = true;
                                 shouldFixXiaoMiShit = true;
                                 updateLastEffectState();
                                 setEffectToNone(mContext);
                             } else {
                                 isEarPhoneConnection = false;
+                                shouldFixXiaoMiShit = true;
                                 resetAudioEffect();
                             }
                         }


### PR DESCRIPTION
通过“shouldFixXiaoMiShit”变量已经可以保证不会因为收到有线耳机断开的广播导致错误的切换音效