### PR TITLE
fix: 修复连接小尾巴时的检测 & 完善音质音效冷启动时的判断逻辑 & 修复清除状态记录时的错误

### DIFF
--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/NewAutoSEffSwitch.java
@@ -76,7 +76,7 @@ public class NewAutoSEffSwitch extends BaseHC {
     }
 
     public static boolean isSupportFW() {
-        return true;
+        return SystemPropTool.getProp("ro.vendor.audio.fweffect", false);
     }
 
     @Override

--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/backups/BackupsUtils.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/backups/BackupsUtils.java
@@ -83,7 +83,9 @@ public class BackupsUtils {
     }
 
     public void clearAll() {
+        boolean isSupportBackups = iPrefsApply.getBoolean("support_backups", false);
         iPrefsApply.editor().clear().apply();
+        iPrefsApply.editor().putBoolean("support_backups", isSupportBackups).apply();
     }
 
     public boolean supportBackups() {

--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/AudioEffectControl.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/AudioEffectControl.java
@@ -145,12 +145,13 @@ public class AudioEffectControl implements IControl {
                             if (isBroadcastReceiverCanUse) return;
                             Object bluetoothDevice = getArgs(1);
                             if (bluetoothDevice != null) {
-                                // isEarPhoneConnection = true; // 这里不赋值 true 为了防止音质音效通过 ACTION_HEADSET_PLUG DISCONNECTED! 切换回音效。
+                                isEarPhoneConnection = true;
                                 shouldFixXiaoMiShit = true;
                                 updateLastEffectState();
                                 setEffectToNone(mContext);
                             } else {
                                 isEarPhoneConnection = false;
+                                shouldFixXiaoMiShit = true;
                                 resetAudioEffect();
                             }
                         }
@@ -436,22 +437,12 @@ public class AudioEffectControl implements IControl {
             mLast3dSurroundEnabled = mBackupsUtils.get3dSurroundState();
         }
 
-        if (mLastDolbyEnabled) {
-            setEnableMiSound(false);
-            setEnableDolbyEffect(true);
-        } else if (mLastMiSoundEnabled) {
-            setEnableMiSound(true);
-            setEnableDolbyEffect(false);
-        } else {
-            // 盲猜音质音效被杀，导致数据丢失。
-            setEnableDolbyEffect(true);
-            setEnableMiSound(false);
-
-            mLast3dSurroundEnabled = true;
-            mLastSpatializerEnabled = (isAvailableSpatializer() && !isEnableSpatializer());
+        if (mLastDolbyEnabled || mLastMiSoundEnabled) {
+            setEnableDolbyEffect(mLastDolbyEnabled);
+            setEnableMiSound(mLastMiSoundEnabled);
+            setEnableSpatializer(mLastSpatializerEnabled);
+            setEnable3dSurround(mLast3dSurroundEnabled);
         }
-        setEnableSpatializer(mLastSpatializerEnabled);
-        setEnable3dSurround(mLast3dSurroundEnabled);
 
         updateAutoSEffSwitchInfo();
         if (mBackupsUtils != null && mBackupsUtils.supportBackups())

--- a/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/FWAudioEffectControl.java
+++ b/app/src/main/java/com/hchen/autoseffswitch/hook/misound/control/FWAudioEffectControl.java
@@ -143,12 +143,13 @@ public class FWAudioEffectControl implements IControl {
                             if (isBroadcastReceiverCanUse) return;
                             Object bluetoothDevice = getArgs(1);
                             if (bluetoothDevice != null) {
-                                // isEarPhoneConnection = true; // 这里不赋值 true 为了防止音质音效通过 ACTION_HEADSET_PLUG DISCONNECTED! 切换回音效。
+                                isEarPhoneConnection = true;
                                 shouldFixXiaoMiShit = true;
                                 updateLastEffectState();
                                 setEffectToNone(mContext);
                             } else {
                                 isEarPhoneConnection = false;
+                                shouldFixXiaoMiShit = true;
                                 resetAudioEffect();
                             }
                         }


### PR DESCRIPTION
通过“shouldFixXiaoMiShit”变量已经可以保证不会因为收到有线耳机断开的广播导致错误的切换音效。
修复了一下“clearAll”方法会把"support_backups"也清除的错误。